### PR TITLE
Improve image cropping when resizing

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import requests
 import zipfile
 import os
 from pptx import Presentation
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageChops
 from io import BytesIO
 import subprocess
 import gc
@@ -336,6 +336,62 @@ def redimensionar_imagem():
         )
     except Exception as e:
         return {'error': f'Erro ao redimensionar imagem: {str(e)}'}, 500
+
+
+@app.route('/cortar-redimensionar-imagem', methods=['POST'])
+def cortar_redimensionar_imagem():
+    if 'image' not in request.files:
+        return {'error': 'Imagem é obrigatória'}, 400
+
+    largura = request.form.get('largura') or request.form.get('width')
+    altura = request.form.get('altura') or request.form.get('height')
+    if not largura or not altura:
+        return {'error': 'Largura e altura são obrigatórios'}, 400
+
+    try:
+        largura = int(largura)
+        altura = int(altura)
+        if largura <= 0 or altura <= 0:
+            raise ValueError
+    except ValueError:
+        return {'error': 'Largura e altura devem ser números inteiros positivos'}, 400
+
+    try:
+        img_file = request.files['image']
+        img = Image.open(img_file.stream).convert('RGB')
+
+        gray = img.convert('L')
+        thresh = 250
+        pixels = gray.load()
+        top = 0
+        bottom = gray.height
+
+        while top < bottom and all(pixels[x, top] >= thresh for x in range(gray.width)):
+            top += 1
+
+        while bottom > top and all(pixels[x, bottom - 1] >= thresh for x in range(gray.width)):
+            bottom -= 1
+
+        if top > 0 or bottom < gray.height:
+            img = img.crop((0, top, img.width, bottom))
+
+        img = img.resize((largura, altura))
+
+        output = BytesIO()
+        formato = img.format or 'PNG'
+        img.save(output, format=formato)
+        output.seek(0)
+
+        mimetype = img_file.mimetype or f'image/{formato.lower()}'
+        ext = formato.lower()
+        return send_file(
+            output,
+            mimetype=mimetype,
+            as_attachment=True,
+            download_name=f'resized.{ext}'
+        )
+    except Exception as e:
+        return {'error': f'Erro ao processar imagem: {str(e)}'}, 500
 
 
 @app.route('/pptx-para-pdf', methods=['POST'])


### PR DESCRIPTION
## Summary
- refine `/cortar-redimensionar-imagem` logic
- scan image rows for near-white pixels to crop blank top/bottom before resizing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687d512a2384832d964a07381e97d230