### PR TITLE
feat: add HTML to video render endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,15 +1,20 @@
-from flask import Flask, request, send_file
+from flask import Flask, request, send_file, jsonify, after_this_request
 import fitz  # PyMuPDF
 import tempfile
 import json
 import requests
 import zipfile
 import os
+import re
+import shutil
+import time
+from pathlib import Path
 from pptx import Presentation
 from PIL import Image, ImageDraw, ImageChops, ImageOps
 from io import BytesIO
 import subprocess
 import gc
+from playwright.sync_api import sync_playwright
 from werkzeug.utils import secure_filename
 from urllib.parse import urlparse, unquote
 from PIL import ImageFont
@@ -498,6 +503,401 @@ def pptx_para_pdf():
 
     except Exception as e:
         return {'error': f'Erro ao processar PPTX: {str(e)}'}, 500
+
+
+# ================= Vídeo a partir de HTML =================
+
+# =============== Defaults (pode ajustar) ===============
+TARGET_FPS       = 30        # fps do MP4 final
+CONTENT_SECONDS  = 10.0      # conteúdo útil aproximado
+BUFFER_HEAD_S    = 2.0       # buffer antes
+BUFFER_TAIL_S    = 2.0       # buffer depois
+SCENE_THRESHOLD  = 0.0015    # sensibilidade do auto-trim do início
+HEAD_PAD_S       = 0.05      # margem antes do 1º movimento
+TAIL_PAD_S       = 0.10      # margem após o último movimento (apenas se cortar o final)
+AUTO_TRIM_HEAD   = True      # corta automaticamente o início ESTÁTICO
+AUTO_TRIM_TAIL   = False     # não corta o final por padrão
+ZERO_ANIM_DELAY  = True      # zera animation/transition-delay (padrão; pode sobrescrever por requisição)
+WAIT_NETWORK_IDLE= True
+TIMEZONE_ID      = "America/Sao_Paulo"
+AUTO_SIZE_BODY   = True      # mede o <body> e grava no tamanho exato
+MAX_DIM          = 4096      # limite por dimensão para o viewport gravado
+# Qualidade/compat do MP4
+CRF              = 20
+PRESET           = "medium"
+PIX_FMT          = "yuv420p"
+PROFILE          = "high"
+LEVEL            = "4.0"
+# =======================================================
+
+
+def ensure_ffmpeg():
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        raise RuntimeError("FFmpeg/ffprobe não encontrados no PATH.")
+
+
+def file_url(p: Path) -> str:
+    return p.resolve().as_uri()
+
+
+def measure_body_size(html_path: Path) -> tuple[int, int]:
+    """Abre SEM gravação, mede o tamanho real do <body> e devolve (w,h)."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        ctx = browser.new_context(
+            viewport={"width": 1080, "height": 1350},
+            device_scale_factor=1.0,
+            java_script_enabled=True,
+            timezone_id=TIMEZONE_ID,
+        )
+        page = ctx.new_page()
+        page.goto(file_url(html_path), wait_until="load")
+        if WAIT_NETWORK_IDLE:
+            try:
+                page.wait_for_load_state("networkidle", timeout=8000)
+            except Exception:
+                pass
+        try:
+            page.evaluate("document.fonts && document.fonts.ready && document.fonts.ready.then(()=>{})")
+            page.wait_for_timeout(50)
+        except Exception:
+            pass
+        dims = page.evaluate(
+            """
+        () => {
+          const b = document.body, d = document.documentElement;
+          const w = Math.max(b.scrollWidth, d.scrollWidth, b.offsetWidth, d.offsetWidth, d.clientWidth);
+          const h = Math.max(b.scrollHeight, d.scrollHeight, b.offsetHeight, d.offsetHeight, d.clientHeight);
+          return {w, h};
+        }
+        """
+        )
+        ctx.close()
+        browser.close()
+    w = max(1, int(dims["w"]))
+    h = max(1, int(dims["h"]))
+    if w > MAX_DIM or h > MAX_DIM:
+        r = min(MAX_DIM / w, MAX_DIM / h)
+        w, h = max(1, int(w * r)), max(1, int(h * r))
+    return w, h
+
+
+def prepare_page(page, *, zero_anim_delay: bool):
+    page.wait_for_load_state("load")
+    if WAIT_NETWORK_IDLE:
+        try:
+            page.wait_for_load_state("networkidle", timeout=8000)
+        except Exception:
+            pass
+    try:
+        page.evaluate("document.fonts && document.fonts.ready && document.fonts.ready.then(()=>{})")
+        page.wait_for_timeout(50)
+    except Exception:
+        pass
+    if zero_anim_delay:
+        page.add_style_tag(
+            content="""
+            * { animation-delay: 0s !important; transition-delay: 0s !important; }
+        """
+        )
+
+
+def record_webm(
+    html_path: Path,
+    total_seconds: float,
+    width: int,
+    height: int,
+    out_dir: Path,
+    *,
+    zero_anim_delay: bool,
+) -> Path:
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        ctx = browser.new_context(
+            viewport={"width": width, "height": height},
+            record_video_dir=str(out_dir),
+            record_video_size={"width": width, "height": height},
+            device_scale_factor=1.0,
+            java_script_enabled=True,
+            timezone_id=TIMEZONE_ID,
+        )
+        page = ctx.new_page()
+        page.goto(file_url(html_path), wait_until="load")
+        prepare_page(page, zero_anim_delay=zero_anim_delay)
+        page.wait_for_timeout(500)  # warmup
+        page.wait_for_timeout(int(total_seconds * 1000))
+        page.close()
+        ctx.close()
+        browser.close()
+    vids = sorted(out_dir.rglob("*.webm"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not vids:
+        raise RuntimeError("Nenhum WEBM gravado.")
+    return vids[0]
+
+
+def video_duration(path: Path) -> float:
+    out = subprocess.check_output(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=nokey=1:noprint_wrappers=1",
+            str(path),
+        ]
+    ).decode().strip()
+    try:
+        return float(out)
+    except Exception:
+        return 0.0
+
+
+def detect_scene_changes(path: Path, threshold: float) -> list[float]:
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-i",
+        str(path),
+        "-filter:v",
+        f"select='gt(scene,{threshold})',showinfo",
+        "-an",
+        "-f",
+        "null",
+        "-",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    times = []
+    for line in proc.stderr.splitlines():
+        m = re.search(r"pts_time:([0-9]+\.[0-9]+)", line)
+        if m:
+            try:
+                times.append(float(m.group(1)))
+            except Exception:
+                pass
+    return times
+
+
+def compute_trim(
+    webm: Path,
+    *,
+    auto_head=True,
+    auto_tail=False,
+    head_pad=0.05,
+    tail_pad=0.10,
+    scene_threshold: float = SCENE_THRESHOLD,
+) -> tuple[float, float]:
+    dur = max(0.01, video_duration(webm))
+    if not (auto_head or auto_tail):
+        return 0.0, dur
+    sc = detect_scene_changes(webm, scene_threshold)
+    if not sc:
+        return 0.0, dur
+    start = max(0.0, sc[0] - head_pad) if auto_head else 0.0
+    if auto_tail:
+        end = min(dur, sc[-1] + tail_pad)
+        take = max(0.01, end - start)
+    else:
+        take = max(0.01, dur - start)
+    return start, take
+
+
+def webm_to_mp4_precise(
+    webm_path: Path,
+    mp4_path: Path,
+    start: float,
+    take: float,
+    out_w: int,
+    out_h: int,
+    fps: int,
+):
+    # Usa -ss DEPOIS do -i para seek preciso; mantém a mesma dimensão (sem barras).
+    vf_chain = f"fps={fps}"
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(webm_path),
+        "-ss",
+        f"{start}",
+        "-t",
+        f"{take}",
+        "-vf",
+        vf_chain,
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        PIX_FMT,
+        "-profile:v",
+        PROFILE,
+        "-level:v",
+        LEVEL,
+        "-preset",
+        PRESET,
+        "-crf",
+        str(CRF),
+        "-movflags",
+        "+faststart",
+        "-an",
+        str(mp4_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def write_temp_html(tmpdir: Path, *, html_text: str = None, html_file=None) -> Path:
+    """
+    Grava o HTML recebido (texto ou arquivo enviado) no tmpdir e retorna o caminho.
+    Mantém o nome base do upload (caso tenha assets relativos ao lado).
+    """
+    if html_text is not None:
+        p = tmpdir / "index.html"
+        p.write_text(html_text, encoding="utf-8")
+        return p
+    else:
+        if html_file is None:
+            raise ValueError("Nenhum HTML fornecido.")
+        filename = getattr(html_file, "filename", None) or "upload.html"
+        p = tmpdir / Path(filename).name
+        html_file.save(p)
+        return p
+
+
+@app.route("/healthz")
+def health():
+    return {"ok": True}
+
+
+@app.route("/render", methods=["POST"])
+def render():
+    """
+    POST /render
+    Form-data:
+      - file: arquivo .html  (opcional se mandar 'html')
+      - html: texto bruto do HTML (opcional se mandar 'file')
+      - content_seconds (float, opcional) | default CONTENT_SECONDS
+      - width,height (int, opcionais) | se omitidos e AUTO_SIZE_BODY=True → usa tamanho do <body>
+      - target_fps (int, opcional) | default TARGET_FPS
+      - auto_trim_head (bool), auto_trim_tail (bool) [0/1, true/false]
+      - zero_anim_delay (bool)
+      - scene_threshold, head_pad, tail_pad (opcionais)
+    Resposta: video/mp4 (attachment)
+    """
+    try:
+        ensure_ffmpeg()
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+    html_file = request.files.get("file")
+    html_text = request.form.get("html")
+    if not html_file and not html_text:
+        return jsonify({"error": "Envie 'file' (multipart) OU 'html' (texto)."}), 400
+
+    # parâmetros opcionais
+    try:
+        content_seconds = float(request.form.get("content_seconds", CONTENT_SECONDS))
+    except ValueError:
+        return jsonify({"error": "content_seconds inválido"}), 400
+    try:
+        target_fps = int(request.form.get("target_fps", TARGET_FPS))
+    except ValueError:
+        return jsonify({"error": "target_fps inválido"}), 400
+
+    auto_trim_head = (
+        str(request.form.get("auto_trim_head", str(AUTO_TRIM_HEAD))).lower()
+        in ("1", "true", "t", "yes", "y")
+    )
+    auto_trim_tail = (
+        str(request.form.get("auto_trim_tail", str(AUTO_TRIM_TAIL))).lower()
+        in ("1", "true", "t", "yes", "y")
+    )
+    zero_anim_delay = (
+        str(request.form.get("zero_anim_delay", str(ZERO_ANIM_DELAY))).lower()
+        in ("1", "true", "t", "yes", "y")
+    )
+
+    scene_threshold = request.form.get("scene_threshold")
+    head_pad = request.form.get("head_pad")
+    tail_pad = request.form.get("tail_pad")
+    try:
+        scene_threshold = (
+            float(scene_threshold) if scene_threshold is not None else SCENE_THRESHOLD
+        )
+        head_pad = float(head_pad) if head_pad is not None else HEAD_PAD_S
+        tail_pad = float(tail_pad) if tail_pad is not None else TAIL_PAD_S
+    except ValueError:
+        return jsonify({"error": "scene_threshold/head_pad/tail_pad inválidos"}), 400
+
+    width = request.form.get("width")
+    height = request.form.get("height")
+    try:
+        width = int(width) if width else None
+        height = int(height) if height else None
+    except ValueError:
+        return jsonify({"error": "width/height inválidos"}), 400
+
+    # -------- NÃO usar TemporaryDirectory como context manager (Windows lock) --------
+    tmpdir_obj = tempfile.TemporaryDirectory(prefix="html2mp4_")
+    tmpdir = Path(tmpdir_obj.name)
+
+    @after_this_request
+    def _cleanup(response):
+        # Tenta limpar após o envio (Windows pode segurar handle por um pouco)
+        for _ in range(10):
+            try:
+                tmpdir_obj.cleanup()
+                break
+            except PermissionError:
+                time.sleep(0.3)
+        return response
+
+    try:
+        html_path = write_temp_html(
+            tmpdir, html_text=html_text, html_file=html_file
+        )
+
+        # 1) descobrir tamanho
+        if AUTO_SIZE_BODY and (width is None or height is None):
+            w, h = measure_body_size(html_path)
+        else:
+            w = width or 1080
+            h = height or 1350
+
+        # 2) gravar WEBM com buffers
+        total = content_seconds + BUFFER_HEAD_S + BUFFER_TAIL_S
+        webm = record_webm(
+            html_path, total, w, h, tmpdir, zero_anim_delay=zero_anim_delay
+        )
+
+        # 3) auto-trim do início (e opcional do final), SEM cortar conteúdo
+        start, take = compute_trim(
+            webm,
+            auto_head=auto_trim_head,
+            auto_tail=auto_trim_tail,
+            head_pad=head_pad,
+            tail_pad=tail_pad,
+            scene_threshold=scene_threshold,
+        )
+
+        # 4) converter para MP4 com seek preciso (sem barras)
+        mp4_path = tmpdir / "output.mp4"
+        webm_to_mp4_precise(webm, mp4_path, start, take, w, h, target_fps)
+
+        # 5) devolver (passe string; Flask abre/fecha o arquivo)
+        resp = send_file(
+            str(mp4_path),
+            mimetype="video/mp4",
+            as_attachment=True,
+            download_name="render.mp4",
+            max_age=0,
+            conditional=True,
+        )
+        # Evita cache agressivo de proxies/browsers
+        resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+        resp.headers["Pragma"] = "no-cache"
+        return resp
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.31.0
 python-pptx==0.6.21
 Pillow==10.3.0
 imgkit==1.2.1
+playwright==1.45.0


### PR DESCRIPTION
## Summary
- add /render endpoint to convert HTML content to MP4 using Playwright and FFmpeg
- expose /healthz and helper utilities for video capture and trimming
- include Playwright dependency in requirements

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_689d47973354832da2b3e8abcd65615a